### PR TITLE
Reimplemented `countBy` and `averageBy` with `foldingBy`

### DIFF
--- a/examples/src/main/kotlin/examples/Example2.kt
+++ b/examples/src/main/kotlin/examples/Example2.kt
@@ -29,8 +29,10 @@ fun main(args: Array<String>) {
 
 
     // Get Count by Category
-    val countByCategory=
-            products.countBy { it.category }
+    val countByCategory = products.countBy { it.category }
+    val countByCategory2 = products.groupingBy { it.category }.eachCount()
+
+    assert(countByCategory == countByCategory2)
 
     println("Counts by Category")
     countByCategory.entries.forEach { println(it) }
@@ -41,6 +43,15 @@ fun main(args: Array<String>) {
                     keySelector = { it.category },
                     doubleSelector = { it.defectRate }
             )
+
+    val grouping = products.groupingBy { it.category }
+    val counts = grouping.eachCount()
+    val averageDefectByCategory2 = grouping
+            .fold(0.0) { sum, product -> sum + product.defectRate}
+            .mapValues { (key, sum) -> sum / counts[key]!! }
+
+    assert(averageDefectByCategory == averageDefectByCategory2)
+
 
     println("\nAverage Defect Rate by Category")
     averageDefectByCategory.entries.forEach { println(it) }


### PR DESCRIPTION
Look, I was able to replace `kotlinstatistics` to some extend with `foldingBy`  from stdlib 1.1! Cool, huh?

This PR is *not* for merging, but for discussing the code

I think this is an important point that Kotlin stdlib has some statistic functionality out-of-the-box. Maybe there should be an example on that in your talk. Also, the `kotlinstatistics` example needs to be more involved, so that stdlib function couldn't reproduce it.

Also it got me thinking if we should incorporate `averageBy`  into stdlib as extensions on `Grouping<T, K>`. What do you think?